### PR TITLE
Save time in client not server

### DIFF
--- a/module_routes/newsfeed_routes.js
+++ b/module_routes/newsfeed_routes.js
@@ -9,7 +9,7 @@ router.post('/postcreate', urlencodedParser, async (req, res) => {
     var new_post = ''
     try {
         new_post = req.body.text;
-        var success = save_post(new_post,req.params.dash_id);
+        var success = save_post(new_post,req.body.time,req.params.dash_id);
         while (!success) { }
 
         res.sendStatus(201);
@@ -71,12 +71,12 @@ router.post('/postupdate', urlencodedParser, async (req, res) => {
     }
 })
 
-async function save_post(post_text,dash_id) {
+async function save_post(post_text,post_time,dash_id) {
     console.log(`INSERT INTO posts (posttext,timecode,active,dash_id) VALUES ('${post_text}', LOCALTIME(0),true,${dash_id})`)
     try {
         
 
-        await db.none(`INSERT INTO posts (posttext,timecode,active,dash_id) VALUES ('${post_text}', LOCALTIME(0),true,'${dash_id}')`);
+        await db.none(`INSERT INTO posts (posttext,timecode,active,dash_id) VALUES ('${post_text}', '${post_time}',true,'${dash_id}')`);
 
         return true
     }

--- a/public/scripts/newsfeed.js
+++ b/public/scripts/newsfeed.js
@@ -1,5 +1,6 @@
  	
-    setInterval(reloadPosts,60000);
+ 
+ setInterval(reloadPosts,60000);
     $( document ).ready(function() {
         reloadPosts();
     });

--- a/public/scripts/newsfeed_adminpanel.js
+++ b/public/scripts/newsfeed_adminpanel.js
@@ -1,10 +1,10 @@
-$(document).ready(function () {
 
-});
-
+var DateTime = luxon.DateTime;
 function submitPost() {
     var post_text = $("#postinput").val();
-    $.post("./newsfeed/postcreate", { "text": post_text }, reloadNewsfeed());
+    var now = DateTime.now()
+    $.post("./newsfeed/postcreate", { "text": post_text, "time": now.toLocaleString(DateTime.TIME_SIMPLE) }, reloadNewsfeed());
+    console.log(now.toLocaleString(DateTime.TIME_SIMPLE))
 }
 function reloadNewsfeed() {
     $("#newsfeed").load("./newsfeed/editorload", function (response, status, xhr) {

--- a/views/administration.pug
+++ b/views/administration.pug
@@ -7,7 +7,7 @@ html
     link(rel='stylesheet', href='https://fonts.googleapis.com/css2?family=Rubik+Mono+One&display=swap')
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
     script(src='https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js')
-
+    script(src="https://cdn.jsdelivr.net/npm/luxon@3.5.0/build/global/luxon.min.js")
     
     link(href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0", rel="stylesheet")
     script. 

--- a/views/newsfeed.pug
+++ b/views/newsfeed.pug
@@ -1,3 +1,4 @@
+
 - const numposts = posts.length 
 - var i = numposts - 1
 if dash_id == "dmelb"

--- a/views/newsfeed_admin.pug
+++ b/views/newsfeed_admin.pug
@@ -1,3 +1,4 @@
+
 script(src='/scripts/newsfeed_adminpanel.js')
 
 div#newpost


### PR DESCRIPTION
This solves the timezone issue by avoiding it - megagames will very rarely be played across timezones (or even a single day) so posts can just be saved with the time from the client rather than the server and they'll always be correct for all readers.